### PR TITLE
docs(issue): add bilingual issue forms and a security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,97 @@
+name: Bug 报告 / Bug report
+description: 报告一个缺陷 / Report something that doesn't work
+labels: [bug]
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: 受影响部分 / Affected part
+      description: |
+        不确定就选「不确定」,不要猜。
+        Pick "Not sure" rather than guessing.
+      options:
+        - 后端内核 / Backend kernel
+        - 前端模板 / Web template
+        - 两者 / Both
+        - 不确定 / Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: 版本 / Version
+      description: |
+        NuGet 包版本号;从源码运行请给 git commit SHA。
+        NuGet package version, or the git commit SHA if you run from source.
+      placeholder: 0.1.0 或 / or bbb9803
+    validations:
+      required: true
+
+  - type: dropdown
+    id: database
+    attributes:
+      label: 数据库 / Database
+      description: |
+        用哪个数据库跑出来的。与数据库无关的问题选「不涉及」。
+        Which database you hit this on. Pick "Not applicable" if it isn't database-related.
+      options:
+        - SQLite
+        - MySQL
+        - SqlServer
+        - PostgreSQL
+        - 不涉及 / Not applicable
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: 复现步骤 / Steps to reproduce
+      description: |
+        请给出最小可复现步骤;能附一个最小复现仓库最好。
+        Minimal steps to reproduce. A minimal repro repo is ideal.
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-actual
+    attributes:
+      label: 期望 vs 实际 / Expected vs actual
+      description: |
+        你以为会发生什么,实际发生了什么。
+        What you expected to happen, and what actually happened.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: 日志 / 报错栈 / Logs & stack trace
+      description: |
+        完整的异常栈或相关日志。会自动按代码块渲染,不用加反引号。
+        Full exception stack trace or relevant logs. Rendered as code, no backticks needed.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: 相关配置 / Relevant configuration
+      description: |
+        选填。appsettings.json 的相关片段等 —— 记得抹掉连接串里的密码。
+        Optional. Relevant appsettings.json snippets — redact credentials first.
+      render: json
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: 截图或补充 / Screenshots or anything else
+      description: |
+        选填。
+        Optional.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🔒 安全漏洞 / Security vulnerability
+    url: https://github.com/Tenon-Net/TenonAdmin/security/advisories/new
+    about: 请勿公开提交安全漏洞 —— 走私密上报,修好后再一起披露。/ Never report a security issue publicly. Use private reporting; we'll disclose together once it's fixed.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: 功能建议 / Feature request
+description: 提一个需求或改进 / Suggest a feature or improvement
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: 你要解决什么问题 / What problem are you trying to solve
+      description: |
+        请描述你的场景和卡点,而不是直接描述你想要的功能 —— 前者才能让我们判断该不该进内核,以及有没有更好的解法。
+        Describe your situation and what blocks you, rather than the feature you already have in mind. That lets us judge whether it belongs in the kernel, and whether there's a better answer.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: 受影响部分 / Affected part
+      options:
+        - 后端内核 / Backend kernel
+        - 前端模板 / Web template
+        - 两者 / Both
+    validations:
+      required: true
+
+  - type: textarea
+    id: replaceability
+    attributes:
+      label: 你试过自己重写实现吗 / Have you tried overriding it yourself
+      description: |
+        TenonAdmin 的设计前提是可替换:每个服务都用 TryAdd 注册,你在 AddTenonAdmin() 之前注册同接口的实现就会覆盖内置的;长方法都拆成了 virtual 步骤,子类重写其中一步即可,不必 fork。
+        请说明你试过哪条路、卡在哪。如果自己重写就能解决,那它多半不该进内核;而如果你发现某处**没法**重写,那本身就是个值得修的缺陷 —— 请直接说。
+
+        TenonAdmin is built to be replaced: every service is registered via TryAdd (register your own implementation before AddTenonAdmin() and yours wins), and long methods are split into virtual steps you can override in a subclass — no fork needed.
+        Tell us what you tried and where it broke down. If overriding solves it, it probably doesn't belong in the kernel. If you found something that *can't* be overridden, that's a defect worth fixing — say so.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 期望的方案 / Proposed solution
+      description: |
+        选填。有具体想法就写,没有也没关系 —— 上面的问题描述比这里重要。
+        Optional. Write it if you have one; the problem statement above matters more.
+
+  - type: checkboxes
+    id: pr
+    attributes:
+      label: 参与意愿 / Willing to contribute
+      options:
+        - label: 我愿意为此提一个 PR / I'm willing to open a PR for this

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,30 @@
+name: 使用问题 / Question
+description: 使用中的疑问 —— 不确定是不是 bug 也走这里 / Ask how to do something — also fine if you're not sure it's a bug
+labels: [question]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: 你的问题 / Your question
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: 相关部分 / Related part
+      options:
+        - 后端内核 / Backend kernel
+        - 前端模板 / Web template
+        - 两者 / Both
+        - 不确定 / Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: 相关配置或代码 / Relevant config or code
+      description: |
+        选填 —— 贴上能帮我们答得准一点。记得抹掉密码。
+        Optional — helps us answer precisely. Redact credentials first.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# 安全策略 / Security Policy
+
+## 报告漏洞
+
+**请勿通过公开 issue 报告安全漏洞。** TenonAdmin 以 NuGet 包分发,承载认证、RBAC 与多组织数据权限 —— 一份公开的漏洞报告等于对所有下游使用者的 0-day 披露,而那时补丁还不存在。
+
+请走 [私密漏洞上报](https://github.com/Tenon-Net/TenonAdmin/security/advisories/new)。我们会在 **7 天内**回复;确认后与你协调修复与披露的时间。
+
+## Reporting a vulnerability
+
+**Do not report security vulnerabilities through public issues.** TenonAdmin ships as NuGet packages and carries authentication, RBAC, and multi-org data permissions — a public report is a 0-day disclosure against every downstream consumer, before a patch exists.
+
+Use [private vulnerability reporting](https://github.com/Tenon-Net/TenonAdmin/security/advisories/new). We aim to respond within **7 days**, and will coordinate the fix and disclosure timeline with you.
+
+## 受支持的版本 / Supported versions
+
+项目尚未发布正式版本,当前仅 `main` 分支受支持。发布后此处会改为受支持的版本范围。
+
+No release has been published yet; only `main` is currently supported. This section will list supported version ranges once releases begin.


### PR DESCRIPTION
三个 Issue Form(Bug / 功能建议 / 使用问题)+ 安全策略,全部中英双语。空白 issue 入口关闭 —— 三个模板已覆盖所有来路。

## 决策与理由

- **Bug 表单必填 6 项**:受影响部分、版本、数据库、复现步骤、期望vs实际、日志。**不要** OS 和 .NET SDK 版本 —— TFM 被 `Directory.Build.props` 钉死在 `net10.0`,这两项在每份报告里都是噪音,只会劝退提交。也没有「我已搜索重复」复选框(没人认真勾)。
- **版本用自由文本而非下拉框**:仓库刚切 0.1.0,还没发过包,现在的使用者都是跑源码的 —— 他们手里只有 commit SHA。下拉框还会随每次发版腐烂。等发到第 5 个版本、且多数人真的在装包时再议。
- **功能建议问「你试过自己重写吗」**:可替换性是内核的设计前提(`TryAdd` 覆盖 + `virtual` 步骤重写)。很大一部分需求的正确答案是「你不用等我加」,这个字段让提交者自己先走一遍。反过来,如果他发现某处**没法**重写,那是个真缺陷。
- **使用问题表单刻意做成最轻的**(3 个字段):空白入口已关,如果它比 Bug 表单还难填,人就会去点 Bug 表单 —— 那比不做还糟。
- **只自动打类型标签** `bug`/`enhancement`/`question`(三个线上都已存在)。不打 `needs-triage`:反向标签要靠维护者每次手动摘,忘几次就没信息量了。

## 安全

已启用 GitHub Private vulnerability reporting(`{"enabled":true}`),`config.yml` 给它一条模板之外的入口。认证 / RBAC / 数据权限内核上的洞公开提交 = 对所有下游的 0-day,而现在用户为零,正是补这条通道成本最低的时刻。

## 生效时机

Issue 模板**只从默认分支(`main`)读取**,在 `dev` 上不生效 —— 会随 0.1.0 合入 main 时一起生效。合并后建议实际点开一次「新建 issue」确认三个卡片都在:GitHub 自己的表单 schema 校验只在默认分支上跑。

## 验证

四个 YAML 均解析通过,字段数与设计一致(bug 8/必填6、feature 5/必填3、question 3/必填2);引用的三个标签线上均存在,不会静默跳过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)