### PR TITLE
feat(sqlsugar): PrimaryId 基类,支持无审计字段的明细/子表 (#8)

### DIFF
--- a/backend/src/TenonAdmin.SqlSugar/Entities/BaseEntity.cs
+++ b/backend/src/TenonAdmin.SqlSugar/Entities/BaseEntity.cs
@@ -13,8 +13,24 @@ public interface ISoftDelete
     bool IsDelete { get; set; }
 }
 
-// ponytail: BaseEntity 暂放 SqlSugar 层(携带 SqlSugar 特性)。
+// ponytail: BaseEntity/PrimaryId 暂放 SqlSugar 层(携带 SqlSugar 特性)。
 // 设计 §5.6 归 Core;待 Core 改用无特性 POCO + 外部映射时再迁移。
+/// <summary>
+/// 仅主键基类(#8):只有雪花主键 <see cref="Id"/>,不带审计字段、不带软删除。
+/// <para>给<b>明细/子表</b>这类不需要审计四件套的实体用(如主从表的从表 <c>XxxDetail</c>)。继承本类即自动获得:</para>
+/// <list type="bullet">
+///   <item>插入时 Id==0 → 自动填雪花 ID(与 <see cref="BaseEntity"/> 共用 SqlSugarSetup 的审计 AOP,按 <c>PrimaryId</c> 匹配);显式给定的 Id 原样保留</item>
+/// </list>
+/// <para><b>与 <see cref="BaseEntity"/> 的取舍:</b>PrimaryId 更轻,但内置泛型仓储 <c>IRepository&lt;T&gt;</c> 与种子 <c>ISeedData&lt;T&gt;</c>
+/// 仍约束 <c>where T : BaseEntity</c> —— 故 PrimaryId-only 实体<b>用不了内置仓储、不能种子化</b>,通常经 <c>ISqlSugarClient</c>
+/// 随主表在同一事务里读写。需要审计留痕/软删/被仓储托管的表,继续用 <see cref="BaseEntity"/>。</para>
+/// </summary>
+public abstract class PrimaryId
+{
+    [SugarColumn(IsPrimaryKey = true, ColumnDescription = "主键(雪花 ID;种子数据用固定小整数)")]
+    public long Id { get; set; }
+}
+
 /// <summary>
 /// 实体基类(设计 §5.6/§12):主键 + 审计四件套 + 软删除。
 /// <para>继承本类即自动获得(由 SqlSugarSetup 的 AOP 钩子驱动,业务代码零感知):</para>
@@ -24,13 +40,10 @@ public interface ISoftDelete
 ///   <item>CreateUserId / UpdateUserId 由当前登录用户上下文填充(认证闭环接入后生效)</item>
 ///   <item>查询自动过滤 IsDelete == true 的行(全局软删过滤器)</item>
 /// </list>
-/// <para>带机构数据范围的业务实体应继承 <c>DataEntity</c>(随组织模块引入,含机构字段)。</para>
+/// <para>主键 <c>Id</c> 由 <see cref="PrimaryId"/> 提供;带机构数据范围的业务实体应继承 <c>DataEntity</c>(随组织模块引入,含机构字段)。</para>
 /// </summary>
-public abstract class BaseEntity : ISoftDelete
+public abstract class BaseEntity : PrimaryId, ISoftDelete
 {
-    [SugarColumn(IsPrimaryKey = true, ColumnDescription = "主键(雪花 ID;种子数据用固定小整数)")]
-    public long Id { get; set; }
-
     [SugarColumn(ColumnDescription = "创建时间")]
     public DateTime CreateTime { get; set; }
 

--- a/backend/src/TenonAdmin.SqlSugar/SqlSugarSetup.cs
+++ b/backend/src/TenonAdmin.SqlSugar/SqlSugarSetup.cs
@@ -86,8 +86,10 @@ public static class SqlSugarSetup
                     switch (info.OperationType)
                     {
                         case DataFilterType.InsertByObject:
-                            // Id 未指定(=0)→ 填雪花号;种子等显式指定的 Id 原样保留
-                            if (info is { PropertyName: nameof(BaseEntity.Id), EntityValue: BaseEntity { Id: 0 } })
+                            // Id 未指定(=0)→ 填雪花号;种子等显式指定的 Id 原样保留。
+                            // 按 PrimaryId 匹配(而非 BaseEntity):BaseEntity : PrimaryId,故老实体一并覆盖,
+                            // 且明细/子表(仅继承 PrimaryId,无审计字段,#8)插入时同样自动获得雪花 Id。
+                            if (info is { PropertyName: nameof(PrimaryId.Id), EntityValue: PrimaryId { Id: 0 } })
                                 info.SetValue(idGen.NextId());
                             // CreateTime 未指定 → 填当前时间
                             else if (info is { PropertyName: nameof(BaseEntity.CreateTime), EntityValue: BaseEntity { CreateTime: var ct } } && ct == default)

--- a/backend/tests/TenonAdmin.Tests/PrimaryIdEntityTests.cs
+++ b/backend/tests/TenonAdmin.Tests/PrimaryIdEntityTests.cs
@@ -1,0 +1,48 @@
+using Microsoft.Extensions.DependencyInjection;
+using SqlSugar;
+using TenonAdmin.Core;
+using TenonAdmin.SqlSugar;
+
+namespace TenonAdmin.Tests;
+
+/// <summary>
+/// 仅主键基类 <see cref="PrimaryId"/>(#8):明细/子表继承它,不带审计四件套与软删,
+/// 但插入时仍由审计 AOP 自动获得雪花 Id —— 该填充按 <c>PrimaryId</c>(而非 <c>BaseEntity</c>)匹配,才覆盖到这类实体。
+/// <para>刻意不走 <c>IRepository&lt;T&gt;</c>(它约束 <c>where T : BaseEntity</c>,PrimaryId-only 实体本就用不了),
+/// 直接经 <c>ISqlSugarClient</c> 读写,正是主从表里从表的典型用法。</para>
+/// </summary>
+public class PrimaryIdEntityTests
+{
+    /// <summary>范例"明细子表"实体:只有主键 + 业务字段,无审计/软删列。</summary>
+    [SugarTable("primaryid_detail_test")]
+    private sealed class DetailRow : PrimaryId
+    {
+        [SugarColumn(Length = 32, ColumnDescription = "名称")]
+        public string Name { get; set; } = "";
+    }
+
+    [Fact]
+    public async Task PrimaryIdOnlyEntity_GetsSnowflakeId_OnInsert()
+    {
+        var id = $"pid-{Guid.NewGuid():N}";
+        var dbFile = Path.Combine(Path.GetTempPath(), $"tenon-{id}.db");
+
+        var services = new ServiceCollection();
+        services.AddTenonAdminSqlSugar(
+            new AdminDatabaseOptions { DbType = TestDb.DbType, ConnectionString = TestDb.ConnectionString(id, dbFile) });
+        await using var sp = services.BuildServiceProvider();
+
+        var db = sp.GetRequiredService<ISqlSugarClient>();
+        db.CodeFirst.InitTables<DetailRow>();   // 无 BaseEntity 也能建表:建表按 [SugarTable] 扫描,不认基类
+
+        var row = new DetailRow { Name = "bom-detail" };   // Id 未指定(=0)
+        await db.Insertable(row).ExecuteCommandAsync();
+
+        var stored = await db.Queryable<DetailRow>().FirstAsync(x => x.Name == "bom-detail");
+        // ≥ SnowflakeFloor(4096)才证明是 AOP 填的雪花号,而非 SQLite rowid(=1)之类的兜底填充
+        Assert.True(stored.Id >= TenonSeedIds.SnowflakeFloor,
+            $"PrimaryId-only 实体应由审计 AOP 自动填雪花 Id(≥{TenonSeedIds.SnowflakeFloor}),实际 {stored.Id}");
+
+        TestDb.Cleanup(id, dbFile);
+    }
+}

--- a/docs/review/patrol-ledger.md
+++ b/docs/review/patrol-ledger.md
@@ -1,12 +1,12 @@
 # 巡检台账
 
-last-seen: 85cf36e
+last-seen: b322c10
 last-tree: c658ff1
-dry-streak: 1
+dry-streak: 2
 
 ## 待扫
 
-<!-- 空(第 20 轮空转):85cf36e 为纯文档站提交(site/guide/*),不碰 backend/src·web/src,门控无入队。真实代码全扫完。等新代码提交(last-seen 85cf36e 之后)或新工作区变更(last-tree c658ff1 变化)入队。 -->
+<!-- 空(第 21 轮空转):85cf36e..b322c10 三提交(round-20 台账 / 7b298cb 0.1.2 发版准备:changelog+web 版本号〔走 package.json 注入,非 web/src〕/ b322c10 发版 runbook)均不碰 backend/src·web/src,门控无入队。真实代码全扫完。等新代码提交(last-seen b322c10 之后)或新工作区变更(last-tree c658ff1 变化)入队。 -->
 
 ## 待裁决
 
@@ -71,3 +71,5 @@ menu/index.vue 主表对每个动作严格 v-auth/hasPerm(增/改/删/启停,lin
 ### 第 19 轮 — 前端规范轴 + 契约轴 · 扫了 locales/index.ts / locales/index.spec.ts / locales/ext/README.md(i18n 扩展接缝,第 17 轮曾以工作区避让态验过,现于 a87da64 提交后以已提交态复核)· 全合规(index.ts:withExt/deepMerge glob 接缝——§2.1 上游自留地基础设施、导出 withExt 有站内调用方非死代码、深合并 spread 不改入参;§2.7 无可见文本;契约轴:接缝只合并不新增键、ext/ 现仅 README〔sampleDoc 已删〕→ glob 空、withExt 原样返回、606 键零漂移;index.spec.ts 8 例覆盖已绿;ext/README `[MsgKey]` 去前缀对齐指引准确)。触发源:用户令我先提交工作区那批避让文件(feat a87da64 前端接缝 + docs bb199f6 文件归属文档),门控把其中 3 个 web/src 文件入队。全合规无发现、无机械修。闸门:提交前已跑 npm test 39/39 + typecheck 无错(绿)。last-seen→bb199f6、last-tree→c658ff1、dry-streak 归 0(本轮队列非空、扫了真实代码)。队列出清。NEXT: 队列空 → 下轮 dry-streak 起(退避 min(3600,900·2^n));真实代码零待扫,等新提交或新工作区变更。
 
 ### 第 20 轮 — 空转轮 · 门控:bb199f6..HEAD 对 backend/src·web/src 差异为空、工作区干净、哈希仍 c658ff1。区间内唯一新提交 85cf36e 为纯文档站(site/guide getting-started/sync-fork degit 快照上手方式),不碰代码故无入队。队列空 → dry-streak 0→1,last-seen→85cf36e、last-tree 保持 c658ff1。不扫代码、不跑闸门。退避 min(3600,900·2¹)=1800s。队列剩 0。NEXT: 1800s 后重跑门控;仍无 backend/src·web/src 新增则 dry-streak→2(退避 3600s 封顶);等真实代码提交或工作区变更破空转。
+
+### 第 21 轮 — 空转轮 · 门控:85cf36e..HEAD(=b322c10)对 backend/src·web/src 差异为空、工作区干净、哈希仍 c658ff1。区间三提交均不碰代码:67741fe(round-20 台账)、7b298cb(chore(release) 0.1.2 发版准备——changelog + web 版本号,版本号走 package.json 经 Vite define 注入前端、非 web/src 源码)、b322c10(发版 runbook 文档)。队列空 → dry-streak 1→2,last-seen→b322c10、last-tree 保持 c658ff1。不扫代码、不跑闸门。退避 min(3600,900·2²)=3600s(已封顶)。队列剩 0。NEXT: 3600s 后重跑门控;dry-streak≥2 起退避恒封顶 3600s(streak 仍会 3、4… 递增,退避不变);等真实代码提交或工作区变更即归 0 破空转。注:0.1.2 已切版但零代码改动(纯文档 + 版本元数据),巡检面无新增。


### PR DESCRIPTION
Closes #8

## 背景

明细/子表(如主从表的从表)不需要审计四件套(CreateTime / CreateUserId / UpdateTime / UpdateUserId)与软删标记,只想要一个统一的雪花主键。#8 提议抽一个仅主键基类。

## 改动(最小三处)

1. **新增 `PrimaryId` 基类**——仅雪花主键 `Id`;`BaseEntity : PrimaryId, ISoftDelete`(增量,不动任何现有实体的列结构)。
2. **审计 AOP 的 Id 填充按 `PrimaryId` 匹配**(原按 `BaseEntity`)。因 `BaseEntity : PrimaryId`,老实体一并覆盖,新的 PrimaryId-only 实体插入时也自动获得雪花 Id。
3. **新增测试** `PrimaryIdEntityTests`:PrimaryId-only 实体经 `ISqlSugarClient` 插入后自动获得雪花 Id(断言 `Id ≥ 4096`,把雪花号与 SQLite rowid 兜底区分开)。

## 为什么其余承重路径无需改

- **CodeFirst 建表**按 `[SugarTable]` 特性扫描(`DatabaseInitializer`),不认基类 → PrimaryId-only 实体照常建表。
- **软删过滤器**认 `ISoftDelete` 接口、**数据范围过滤器**认 `IOrgScoped` 接口 → PrimaryId-only 实体天然不带这俩,正好不被过滤(明细表本就不需要软删/机构隔离)。

## 已知限制(设计取舍)

内置 `IRepository<T>` / `ISeedData<T>` 仍约束 `where T : BaseEntity` —— PrimaryId-only 明细表用不了内置泛型仓储、不能种子化,按主从模式经 `ISqlSugarClient` 随主表在同一事务里读写。真有需要再单独放开。

`CreateTableFieldSort`(审计列排到表尾)是纯 DDL 列序、只在表开 `IsCreateTableFiledSort` 时生效,未塞进内核基类,消费者可自行在自己的表上开。

## 验证

`dotnet test backend/TenonAdmin.slnx -c Release`:**268 passed, 0 failed**(含六件套 `ReplaceabilityTests`、种子取号 `SeedIdRangeTests`、软删审计、数据范围)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
