### PR TITLE
perf(ci): run only the dialect-sensitive subset on the SqlServer PR leg

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -7,6 +7,11 @@ on:
     paths: ['backend/**', 'templates/**', '.github/workflows/backend-ci.yml']
   pull_request:
     paths: ['backend/**', 'templates/**', '.github/workflows/backend-ci.yml']
+  # Nightly full run: every DB leg runs the WHOLE suite, including the slow SqlServer full pass (40-60 min)
+  # that push/PR deliberately skips (see the SqlServer filter in the Test step). schedule ignores `paths`,
+  # so this always fires — the safety net that catches anything the PR-time SqlServer subset doesn't cover.
+  schedule:
+    - cron: '0 18 * * *'   # 02:00 Asia/Shanghai
 
 jobs:
   build-test:
@@ -120,7 +125,21 @@ jobs:
           TENON_TEST_POSTGRESQL: ${{ matrix.db == 'postgres' && 'Server=127.0.0.1;Port=5432;User ID=postgres;Password=postgres;' || '' }}
           # Gate switch for the Redis contract tests (runs on every leg: it's DB-independent, and running it a few extra times only costs a few seconds).
           TENON_TEST_REDIS: 127.0.0.1:6379
-        run: dotnet test backend/TenonAdmin.slnx -c Release --no-build
+          # SqlServer full suite builds ~200 isolated databases, each replaying 23 CREATE TABLE whose per-statement
+          # log flush dominates — 40-60 min on every push/PR (measured 2026-07-20; see CLAUDE.md "CI"). On push/PR the
+          # SqlServer leg runs only the dialect-sensitive subset: the SqlServer-SPECIFIC surface (nvarchar Chinese,
+          # boolean-predicate global filters, T-SQL DDL/bootstrap, Storageable seed SQL). DB-agnostic business logic is
+          # already covered by the full sqlite/mysql/postgres legs on the same PR; the full SqlServer suite runs nightly
+          # (schedule) as the net. Rename a class out of this list and it silently drops to nightly-only — not a coverage
+          # hole, just delayed signal. Other legs and the nightly run are unfiltered.
+          TEST_FILTER: ${{ (matrix.db == 'sqlserver' && github.event_name != 'schedule') && 'FullyQualifiedName~DataScopeTests|FullyQualifiedName~SoftDeleteAuditTests|FullyQualifiedName~OrgAuditEntityTests|FullyQualifiedName~SeedUpgradeTests|FullyQualifiedName~RecycleBinTests|FullyQualifiedName~UserCrudTests|FullyQualifiedName~DictCrudTests|FullyQualifiedName~ReplaceabilityTests|FullyQualifiedName~ProductionBootstrapTests' || '' }}
+        run: |
+          if [ -n "$TEST_FILTER" ]; then
+            echo "SqlServer push/PR leg: dialect-sensitive subset only (full SqlServer suite runs nightly)"
+            dotnet test backend/TenonAdmin.slnx -c Release --no-build --filter "$TEST_FILTER"
+          else
+            dotnet test backend/TenonAdmin.slnx -c Release --no-build
+          fi
 
   # The consumer's first command (dotnet new tenon-app → restore → build). Previously had zero automated
   # coverage — so the template kept referencing a package version whose tag was never published, and nobody
@@ -140,3 +159,31 @@ jobs:
       - name: dotnet new tenon-app must restore + build
         shell: pwsh
         run: templates/smoke-test.ps1
+
+  # Nightly safety net has teeth only if someone sees it go red. The push/PR SqlServer leg runs a subset;
+  # the full SqlServer suite runs only in the nightly (schedule) run, so a regression that lands outside the
+  # subset surfaces there — but a scheduled run has no PR author watching it. This job turns a red nightly
+  # into a tracked issue (deduped, so a multi-night outage bumps one issue rather than spamming a new one).
+  # Only fires on scheduled runs: push/PR failures already sit in front of their author.
+  nightly-alert:
+    needs: [build-test, template-smoke]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or bump the nightly-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh label create nightly-failure --repo "$REPO" --color B60205 \
+            --description "backend-ci nightly full run failed" 2>/dev/null || true
+          body="Nightly \`backend-ci\` failed — this run includes the **full SqlServer suite** that push/PR deliberately skips (see the \`TEST_FILTER\` note in the workflow / CLAUDE.md CI section). A regression may live outside the push/PR SqlServer subset. Run: $RUN_URL"
+          existing=$(gh issue list --repo "$REPO" --state open --label nightly-failure --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" --body "$body"
+          else
+            gh issue create --repo "$REPO" --title "Nightly backend-ci failed" --label nightly-failure --body "$body"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,23 @@ Vue 3 `<script setup>` + Naive UI + Pinia (persisted) + vue-router + vue-i18n + 
 
 ## CI
 
-`.github/workflows/backend-ci.yml` runs build + test on a `[sqlite, mysql]` matrix (`fail-fast: false`) for pushes/PRs touching `backend/**`. `backend-release.yml` handles NuGet packaging. Keep the SQLite and MySQL test legs green — `TestDb.cs` derives isolated DBs per test from the DB-type env vars.
+`.github/workflows/backend-ci.yml` runs on pushes/PRs touching `backend/**`, `templates/**`, or the workflow itself, with two jobs:
+- **`build-test`** — build + test on a `[sqlite, mysql, sqlserver, postgres]` matrix (`fail-fast: false`, so one red leg doesn't mask the others). MySQL/SqlServer/PostgreSQL/Redis service containers start on *every* leg; `TestDb.cs` derives an isolated DB per test from the DB-type env vars. `TENON_TEST_REDIS` is set on all legs, so the Redis contract tests actually run instead of silently skipping. **On push/PR the SqlServer leg runs only a dialect-sensitive subset** (`TEST_FILTER` in the Test step) — the other three legs run the full suite; see the SqlServer subsection below.
+- **`template-smoke`** — `dotnet new tenon-app` → restore → build, via `templates/smoke-test.ps1` (the same script used for local manual runs). Catches the consumer's very first command breaking while kernel tests are all green.
+
+`docker-smoke.yml` also fires on `backend/**` (and `web/**`), so a backend PR shows two more checks: **`single`** (image comes up, creates tables, seeds, issues a token) and **`multi`** (two replicas behind Caddy — cross-replica force-logout, lockout threshold, cluster-wide rate limit, distinct `WorkerId`, real client IP). Those guarantees only surface with two replicas online, so don't collapse `multi` into `single`.
+
+`backend-release.yml` handles NuGet packaging. Expect **7 checks** on a backend-only PR; keep all of them green.
+
+### The sqlserver leg: dialect-sensitive subset on push/PR, full nightly
+
+The full SqlServer suite ran **40–60 min** (measured 2026-07-20: 2302 / 2466 / 2748 / 3000 / 3124 / 3277 / 3335 / 3514s, all green) vs 3–5 min for the other three legs. It was never hung — just slow — so don't add a short `timeout-minutes` (under ~90 would turn a green leg red), and don't cancel a nightly SqlServer run for "looking stuck".
+
+**Why it's slow (diagnosed, not guessed).** `TestDb` gives every test its own database — near-free on SQLite (a file), MySQL (a directory), PostgreSQL (a `template1` copy), brutal on SQL Server. A micro-benchmark against a real SqlServer (network latency 1.5 ms, so not a network artifact) put **85% of the per-database cost in `CodeFirst.InitTables`**: ~20 s/db, of which ~17.6 s is the 23 `CREATE TABLE`/`CREATE INDEX` statements themselves (each auto-committed → its own transaction-log flush), only ~2.4 s is existence-check round-trips, and `CREATE DATABASE`/`DROP` are rounding error. ×~200 databases ≈ the whole leg.
+
+**What was tried and rejected** (don't re-attempt without new evidence): tmpfs on `/var/opt/mssql` and a targeted `ClearPool` — both *measured as no-ops*. Building the schema once and cloning per test — `DBCC CLONEDATABASE` is fragile under repeated cloning of one source (transient "database may be offline"), and `BACKUP`/`RESTORE` per test was ruinously slow on the test instrument. The schema DDL is disk-bound and there's no cheap per-database shortcut.
+
+**The resolution** is to stop rebuilding ~200 SqlServer schemas on every PR. On push/PR the SqlServer leg runs only the SqlServer-*specific* surface (nvarchar Chinese, boolean-predicate global filters, T-SQL DDL/bootstrap, Storageable seed SQL) via `TEST_FILTER` — DB-agnostic business logic is already exercised by the full sqlite/mysql/postgres legs on the same PR. The **full** SqlServer suite runs nightly (the `schedule` trigger), so nothing is permanently uncovered — a test outside the subset regresses into the nightly run, not into a blind spot. Measurement discipline that cost real time to learn: the baseline's own spread (2302–3514s, 1.5×) means **a single CI run cannot resolve anything smaller than a ~50% change** — repeat runs or measure locally.
 
 ## Agent skills
 


### PR DESCRIPTION
## Problem

The full SqlServer suite ran **40–60 min** on every push/PR while the other three DB legs finished in 3–5. Always green, never red — so it read as a hang and got cancelled twice mid-run on that misread. This puts SqlServer PR feedback back in the matrix's minutes-range.

## Why it was slow — diagnosed, not guessed

`TestDb` gives every test its own database; the suite builds ~200. A micro-benchmark against a real SqlServer (round-trip latency **1.5 ms**, so not a network artifact) broke down the per-database cost:

| phase | cost | note |
|---|---|---|
| `CREATE DATABASE` | 0.3s | rounding error |
| **`CodeFirst.InitTables`** | **20s** | **85% of per-db cost** |
| ├ 23 `CREATE TABLE`/`INDEX` | 17.6s | each auto-committed → own log flush |
| └ existence-check round-trips | 2.4s | |
| `DROP DATABASE` | 3.1s | |

Near-free on SQLite (a file), MySQL (a directory), PostgreSQL (`template1` copy); disk-bound and brutal on SQL Server. ×~200 dbs ≈ the whole leg.

## What was tried and rejected — by measurement

- **tmpfs** on `/var/opt/mssql` and a **targeted `ClearPool`** → both moved the number by nothing (earlier in this PR's history).
- **Build-once-and-clone**: `DBCC CLONEDATABASE` is fragile under repeated cloning of one source (transient *"database may be offline"*, 7/8 tests failed); per-test `BACKUP`/`RESTORE` was ruinously slow on the instrument (10-min timeout, ~2 dbs done). No cheap per-database shortcut exists for the schema DDL.

## The change

Stop rebuilding ~200 SqlServer schemas per PR. On push/PR the SqlServer leg runs only the SqlServer-**specific** surface via `TEST_FILTER` — nvarchar Chinese, boolean-predicate global filters, T-SQL DDL/bootstrap, Storageable seed SQL (**44 tests, verified green locally**). DB-agnostic business logic is already exercised by the full sqlite/mysql/postgres legs on the same PR.

The **full** SqlServer suite runs **nightly** via a new `schedule` trigger — so nothing is permanently uncovered: a test outside the subset regresses into the nightly run, not into a blind spot. Rename a class out of the filter list and it silently drops to nightly-only — degraded signal, not a coverage hole.

Other legs unchanged. `CLAUDE.md`'s CI section updated to match, keeping the measurement-resolution note (the baseline's own 1.5× spread means one CI run can't resolve a sub-50% change).

## Not done

The deeper fix — building ~200 databases at all — is left alone. The clean way to cut it is fewer databases (share where isolation isn't needed), a test-suite refactor with real risk that needs a representative instrument to validate; the available remote SqlServer (slow-disk Linux) is not one. This PR takes the low-risk, high-leverage cut instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
