### PR TITLE
feat(web): adopt daisyUI corporate/business palettes with a texture pass

### DIFF
--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -1,13 +1,14 @@
 # TenonAdmin 设计系统规范(DESIGN.md)
 
 > 设计单源:`../docs/rebuild-design.md` §7。**tokens 单源:[`src/styles/tokens.css`](src/styles/tokens.css)** —— 一切颜色/字号/间距/圆角/阴影都从那里的 CSS 变量取,本文件只做规范说明与「token → Naive UI」映射。
-> 视觉来源(**已改版**):RBAC 后台原型 [`design-mockups/design_handoff_rbac_admin/`](design-mockups/design_handoff_rbac_admin/README.md)(权威说明 = 其 `README.md`);旧稿 `design-mockups/design-tokens.dc.html` 留档。核心调色板(主色 #646CFF / Arco 灰阶 / 四语义色 / 亮暗角色令牌)与旧稿一致;本版细化**圆角(更圆)/ 阴影 / 顶栏毛玻璃 / 侧栏配色 / 主色派生规则 / 6 主色候选 / 密度档**。
+> 视觉来源(**已改版**):RBAC 后台原型 [`design-mockups/design_handoff_rbac_admin/`](design-mockups/design_handoff_rbac_admin/README.md)(权威说明 = 其 `README.md`);旧稿 `design-mockups/design-tokens.dc.html` 留档。本版细化**圆角(更圆)/ 阴影 / 顶栏毛玻璃 / 侧栏配色 / 主色派生规则 / 6 主色候选 / 密度档**。
+> **色板已换(theme-refresh,2026-07)**:调色板整层采 daisyUI(MIT)企业向主题——亮色 corporate、暗色 business(OKLCH 原值转 sRGB hex,warning/error/三级文字按可读性加深);主色 #0082CE。**靛蓝 #646CFF 仅保留为品牌色**(logo / manifest theme-color,不随 accent 变);圆角/字号/间距/阴影体系不变(daisyUI 的 radius 4px/depth 0 未采用)。手法补充:卡片 1px 描边(styles/index.css 质感层)、表头次级色+600 字重(naive-theme.ts)。
 
 ---
 
 ## 1. 设计基调
 
-企业级、精简、留白充分、克制。低饱和主色(明快现代靛蓝 `#646CFF`)+ Arco 系微冷中性灰阶。信息密度按后台管理(正文 14/22,表格可紧凑),明暗双主题对等。参考观感:Soybean / Naive UI Admin。
+企业级、精简、留白充分、克制。corporate 蓝主色(`#0082CE`)+ 纯中性灰阶(深端带藏蓝墨色),暗色为 business 灰。信息密度按后台管理(正文 14/22,表格可紧凑),明暗双主题对等。参考观感:daisyUI corporate/business 色系 + Soybean / Naive UI Admin 的质感手法。
 
 ## 2. Design Tokens(概览,权威值见 `tokens.css`)
 
@@ -46,12 +47,12 @@
 - **按钮层级**:主 `--color-primary`(hover→`-hover`,pressed→`-pressed`)/ 次要(描边 `--color-border` + 文字 `--color-text-secondary`)/ 文本 / 危险(`--color-danger`)/ 禁用(`--color-fill` + `--color-text-disabled`)。高 34,圆角 `--radius-md`。
 - **表格密度**:舒适(行高 58)/ 紧凑(行高 48)两档(运行时可切,存 `app.density`;联动页内边距 24/18、卡片间距 16/12、卡片内边距 20×22/16×18);数值列 `tabular-nums`。
 - **状态反馈**:标签 = 语义 base 文字 + `-bg` 底 + 圆点;空/加载/错误态统一走 Naive 内建占位。
-- **主色可换(运行时)**:6 候选 `#646CFF`(默认)/ `#7C5CFF` / `#0EA5E9` / `#EC4899` / `#F97316` / `#10B981`;切主色 = 按 §7 派生规则从 accent 重算 `--color-primary*`(写到 `document.documentElement`)+ 重建 Naive `themeOverrides`,存 `app.accent`。
+- **主色可换(运行时)**:6 候选 `#0082CE`(默认,corporate 蓝)/ `#7C5CFF` / `#0EA5E9` / `#EC4899` / `#F97316` / `#10B981`;切主色 = 按 §7 派生规则从 accent 重算 `--color-primary*`(写到 `document.documentElement`)+ 重建 Naive `themeOverrides`,存 `app.accent`(旧候选残留由 afterHydrate 回落默认)。
 - **英雄元素(仅登录页/欢迎横幅/头像)**:主按钮渐变 `btnGrad` + 发光 `glowSh` + hover 上浮 `translateY(-2px)`;**应用内常规按钮走 Naive 平面主色**,不满屏渐变。环境动画(柔光/扫光)默认关(沉稳档)。
 
 ## 6. 可访问性
 
-实测对比度(WCAG,两主题):**主文字**(`--color-text-primary`)on 页底/容器 ≈ 13–16:1、**次文字**(`--color-text-secondary`)≈ 7:1 —— 均过 AA(≥4.5)。**占位/辅助文字**(`--color-text-tertiary` #86909C / 暗 #6E7681)≈ 3.2–3.5:1、**白字 on 主色按钮**(#646CFF)≈ 4.1:1 —— 属 AA-large 档,是品牌主色(Claude 靛蓝)自带的天花板;这些仅用于非正文的提示/大字/按钮场景可接受,若某处放 14px 正文级用途需改用 `--color-text-secondary`。焦点态保留可见描边;交互控件键盘可达;语义色不作唯一区分手段(配文字/图标)。
+实测对比度(WCAG,theme-refresh 色板,两主题):**主文字** on 页底/容器 亮 15.1–17.2:1 / 暗 10.3–10.7:1、**次文字** 亮 6.3:1 / 暗 5.7:1 —— 均过 AA(≥4.5)。**占位/辅助文字**(`--color-text-tertiary` #85868E / 暗 #6E6E6E)亮 3.6:1 / 暗 3.2:1、**白字 on 主色按钮** 亮(#0082CE)4.1:1 / 暗(#2E99D7)3.2:1、**语义色文字** on 容器 亮 3.3–4.2:1(warning 已从 daisyUI 原值加深至 #A88400 保 3.5:1)/ 暗 4.4–7.9:1 —— AA-large 档,仅用于非正文的提示/大字/按钮/标签场景可接受,若某处放 14px 正文级用途需改用 `--color-text-secondary`。焦点态保留可见描边;交互控件键盘可达;语义色不作唯一区分手段(配文字/图标)。
 
 ---
 

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -93,8 +93,10 @@ export const useAppStore = defineStore('app', {
   },
   persist: {
     // 迁移:localStorage 残留的旧模式(mixed-nav / full-content / header-mixed)不在新集合 → 回落 vertical。
+    // 主色同理:残留的旧候选(如 #646CFF)已不在 ACCENTS → 回落默认。
     afterHydrate: ({ store }) => {
       if (!LAYOUT_MODES.includes(store.layoutMode)) store.layoutMode = 'vertical'
+      if (!(ACCENTS as readonly string[]).includes(store.accent)) store.accent = ACCENTS[0]
     },
   },
 })

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -46,6 +46,30 @@ a {
   font-variant-numeric: tabular-nums;
 }
 
+/* ── 质感层(spike/theme-refresh,手法源自 XiHan/soybean 调研)─────────
+   容器走描边不走阴影:shadow-sm 亮色几乎隐形、暗色彻底失效;
+   1px 边框 + 圆角在亮暗两态都有清晰轮廓(XiHan .pane 派)。
+   Naive bordered 卡片自带同值边框(themeOverrides borderColor),此规则只补 bordered=false 的。 */
+.n-card {
+  border: 1px solid var(--color-border);
+}
+
+/* 6px 半透明圆角滚动条,track 透明(XiHan design/scrollbar.css 同款)。 */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-thumb {
+  background: rgba(144, 147, 153, 0.4);
+  border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(144, 147, 153, 0.7);
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
 /* 灰阶:整页 filter(随 app.grayscale 由 useTheme 打在 <html>)。用于哀悼日等场景。
    这里曾有个「色弱模式」= filter: invert(0.8),已删:整页反色是照片负片,对色觉障碍毫无帮助
    (红绿仍然分不开,只是全都变了色),声称提供无障碍却什么也没提供,比没有更糟。

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -20,7 +20,7 @@
   --color-gray-800: #2F313F;  /* 正文加强 */
   --color-gray-700: #5D5F6A;  /* 次级文字 */
   --color-gray-600: #7B7C85;  /* 辅助文字 / 图标 */
-  --color-gray-500: #97989F;  /* 占位 / 说明文字 */
+  --color-gray-500: #85868E;  /* 占位 / 说明文字(对比度加深档,≥3:1) */
   --color-gray-400: #BABABF;  /* 禁用文字 */
   --color-gray-300: #D1D1D1;  /* 重边框 / 分隔线(corporate base-300) */
   --color-gray-200: #E3E3E3;  /* 常规边框 */
@@ -38,7 +38,7 @@
         warning/error 原值偏浅、按正文可读加深一档)─────────────── */
   --color-success:        #00A43B;
   --color-success-bg:     #E0F4E7;
-  --color-warning:        #C59B00;
+  --color-warning:        #A88400;
   --color-warning-bg:     #FFF8E0;
   --color-danger:         #D15054;
   --color-danger-bg:      #FFECED;
@@ -51,7 +51,7 @@
   --color-bg-elevated:    #FFFFFF;  /* 弹层 / 下拉 / 抽屉 */
   --color-text-primary:   #181A2A;  /* 主文字 / 标题 */
   --color-text-secondary: #5D5F6A;  /* 次级文字 */
-  --color-text-tertiary:  #97989F;  /* 占位 / 辅助文字 */
+  --color-text-tertiary:  #85868E;  /* 占位 / 辅助文字(白底 3.6:1,AA-large) */
   --color-text-disabled:  #BABABF;  /* 禁用文字 */
   --color-border:         #E3E3E3;  /* 常规边框 / 分隔 */
   --color-border-strong:  #D1D1D1;  /* 强调边框 / 输入描边 */

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -1,6 +1,8 @@
 /**
  * TenonAdmin 设计 tokens —— 唯一色源(single source of truth)
  * 来源:Claude Design 工程「设计系统 Design Tokens」(web/design-mockups/design-tokens.dc.html)提炼。
+ * spike/theme-refresh:色板整层换为 daisyUI(MIT)企业向主题 —— 亮色采 corporate、暗色采 business,
+ *   OKLCH 原值经 sRGB 转换(scripts 同 mix.ts 插值算法);圆角/字号/间距沿用本项目「更圆」体系不随 daisyUI(其 radius 4px/depth 0)。
  *
  * 分层:
  *   1) 原语色板 --color-gray-* / 品牌主色 / 语义色基色 —— 固定值,不随主题翻转。
@@ -13,48 +15,49 @@
  */
 
 :root {
-  /* ── 原语:中性色阶(Arco 系,低饱和微冷灰)────────────────── */
-  --color-gray-900: #1D2129;  /* 主文字 / 标题 */
-  --color-gray-800: #2B303A;  /* 正文加强 */
-  --color-gray-700: #4E5969;  /* 次级文字 */
-  --color-gray-600: #6B7280;  /* 辅助文字 / 图标 */
-  --color-gray-500: #86909C;  /* 占位 / 说明文字 */
-  --color-gray-400: #A9AEB8;  /* 禁用文字 */
-  --color-gray-300: #C9CDD4;  /* 重边框 / 分隔线 */
-  --color-gray-200: #E5E6EB;  /* 常规边框 */
-  --color-gray-100: #F2F3F5;  /* 填充 / hover 底 */
-  --color-gray-50:  #F7F8FA;  /* 页面背景底 */
+  /* ── 原语:中性色阶(daisyUI corporate 系,纯中性灰 + 藏蓝墨色深端)──── */
+  --color-gray-900: #181A2A;  /* 主文字 / 标题(corporate base-content) */
+  --color-gray-800: #2F313F;  /* 正文加强 */
+  --color-gray-700: #5D5F6A;  /* 次级文字 */
+  --color-gray-600: #7B7C85;  /* 辅助文字 / 图标 */
+  --color-gray-500: #97989F;  /* 占位 / 说明文字 */
+  --color-gray-400: #BABABF;  /* 禁用文字 */
+  --color-gray-300: #D1D1D1;  /* 重边框 / 分隔线(corporate base-300) */
+  --color-gray-200: #E3E3E3;  /* 常规边框 */
+  --color-gray-100: #F1F1F1;  /* 填充 / hover 底 */
+  --color-gray-50:  #F0F0F0;  /* 页面背景底(corporate base-200 柔化) */
   --color-white:    #FFFFFF;
 
-  /* ── 原语:品牌主色(明快现代靛蓝,四档态)──────────────────── */
-  --color-primary:         #646CFF;  /* 默认态 · 主按钮 / 链接 / 选中 */
-  --color-primary-hover:   #7D84FF;  /* 悬浮 hover · 加亮一档 */
-  --color-primary-pressed: #5259D1;  /* 按下 pressed / active */
-  --color-primary-light:   #F0F0FF;  /* 浅底 · 选中背景 / 标签底 */
+  /* ── 原语:品牌主色(corporate 蓝,四档态;运行时由 useTheme 按 accent 重写)── */
+  --color-primary:         #0082CE;  /* 默认态 · 主按钮 / 链接 / 选中 */
+  --color-primary-hover:   #2996D6;  /* 悬浮 hover · 加亮一档 */
+  --color-primary-pressed: #006BA9;  /* 按下 pressed / active */
+  --color-primary-light:   #E6F3FA;  /* 浅底 · 选中背景 / 标签底 */
 
-  /* ── 原语:语义色(base + 浅底 light-bg,亮色)─────────────── */
-  --color-success:        #18A058;
-  --color-success-bg:     #E3F3EB;
-  --color-warning:        #F0A020;
-  --color-warning-bg:     #FDF4E4;
-  --color-danger:         #D03050;
-  --color-danger-bg:      #F9E6EA;
-  --color-info:           #2080F0;
-  --color-info-bg:        #E4F0FD;
+  /* ── 原语:语义色(base + 浅底 light-bg,亮色;corporate 语义色,
+        warning/error 原值偏浅、按正文可读加深一档)─────────────── */
+  --color-success:        #00A43B;
+  --color-success-bg:     #E0F4E7;
+  --color-warning:        #C59B00;
+  --color-warning-bg:     #FFF8E0;
+  --color-danger:         #D15054;
+  --color-danger-bg:      #FFECED;
+  --color-info:           #0090B5;
+  --color-info-bg:        #E0F2F6;
 
   /* ── 角色令牌(亮色主题)—— 业务只消费这一层 ─────────────────── */
-  --color-bg-body:        #F7F8FA;  /* 页面背景 / 画布 */
+  --color-bg-body:        #F0F0F0;  /* 页面背景 / 画布 */
   --color-bg-container:   #FFFFFF;  /* 卡片 / 面板容器 */
   --color-bg-elevated:    #FFFFFF;  /* 弹层 / 下拉 / 抽屉 */
-  --color-text-primary:   #1D2129;  /* 主文字 / 标题 */
-  --color-text-secondary: #4E5969;  /* 次级文字 */
-  --color-text-tertiary:  #86909C;  /* 占位 / 辅助文字 */
-  --color-text-disabled:  #A9AEB8;  /* 禁用文字 */
-  --color-border:         #E5E6EB;  /* 常规边框 / 分隔 */
-  --color-border-strong:  #D3D6DB;  /* 强调边框 / 输入描边 */
-  --color-fill:           #F2F3F5;  /* 填充 / 表头 / hover 底 */
-  --color-fill-hover:     #EBEDF0;  /* 行 hover / 悬浮填充 */
-  --color-mask:           rgba(20, 27, 45, 0.45);  /* 遮罩 / 弹窗背景 */
+  --color-text-primary:   #181A2A;  /* 主文字 / 标题 */
+  --color-text-secondary: #5D5F6A;  /* 次级文字 */
+  --color-text-tertiary:  #97989F;  /* 占位 / 辅助文字 */
+  --color-text-disabled:  #BABABF;  /* 禁用文字 */
+  --color-border:         #E3E3E3;  /* 常规边框 / 分隔 */
+  --color-border-strong:  #D1D1D1;  /* 强调边框 / 输入描边 */
+  --color-fill:           #F1F1F1;  /* 填充 / 表头 / hover 底 */
+  --color-fill-hover:     #EAEAEA;  /* 行 hover / 悬浮填充 */
+  --color-mask:           rgba(24, 26, 42, 0.45);  /* 遮罩 / 弹窗背景 */
   --color-header-bg:      rgba(255, 255, 255, 0.82);  /* 顶栏底(配 backdrop-filter: blur(12px)) */
 
   /* ── 字体 ──────────────────────────────────────────────── */
@@ -87,10 +90,10 @@
   --radius-lg: 12px;  /* 卡片 / 面板 / 弹层 */
   --radius-xl: 16px;  /* 登录卡 / 大面板 */
 
-  /* ── 阴影(亮色)三级(design_handoff:shadow-2 更柔更大)──────── */
-  --shadow-1: 0 1px 2px rgba(20, 27, 45, 0.04), 0 2px 6px rgba(20, 27, 45, 0.06);  /* 卡片 card */
-  --shadow-2: 0 10px 30px rgba(20, 27, 45, 0.12);                                  /* 弹层 popover / 卡片 hover 上浮 */
-  --shadow-3: 0 16px 48px rgba(20, 27, 45, 0.18);                                  /* 悬浮 overlay / 抽屉 */
+  /* ── 阴影(亮色)三级(墨色随 corporate base-content 微调)──────── */
+  --shadow-1: 0 1px 2px rgba(24, 26, 42, 0.05), 0 2px 6px rgba(24, 26, 42, 0.06);  /* 卡片 card */
+  --shadow-2: 0 10px 30px rgba(24, 26, 42, 0.12);                                  /* 弹层 popover / 卡片 hover 上浮 */
+  --shadow-3: 0 16px 48px rgba(24, 26, 42, 0.18);                                  /* 悬浮 overlay / 抽屉 */
 
   /* ── 过渡 ──────────────────────────────────────────────── */
   --transition-fast: 0.15s ease;
@@ -98,36 +101,36 @@
 }
 
 /* ══════════════════════════════════════════════════════════
-   暗色主题:只覆盖会翻转的角色令牌 / 主色 / 语义色 / 阴影。
+   暗色主题(daisyUI business):只覆盖会翻转的角色令牌 / 主色 / 语义色 / 阴影。
    原语灰阶、字号、间距、圆角保持不变。
    ══════════════════════════════════════════════════════════ */
 :root[data-theme="dark"] {
-  /* 主色(暗底提亮一档) */
-  --color-primary:         #8B91FF;
-  --color-primary-hover:   #A2A7FF;
-  --color-primary-pressed: #767CF0;
-  --color-primary-light:   #2D3154;
+  /* 主色(corporate 蓝暗底提亮一档;运行时由 useTheme 按 accent 重写) */
+  --color-primary:         #2E99D7;
+  --color-primary-hover:   #4FA9DD;
+  --color-primary-pressed: #267DB0;
+  --color-primary-light:   #233641;
 
-  /* 语义色(暗底 base + 浅底) */
-  --color-success:    #52B882;  --color-success-bg: #16291E;
-  --color-warning:    #F4B858;  --color-warning-bg: #2E2513;
-  --color-danger:     #DC647C;  --color-danger-bg:  #2E171C;
-  --color-info:       #58A0F4;  --color-info-bg:    #15263D;
+  /* 语义色(business;error 原值过暗、提亮一档保可读) */
+  --color-success:    #6BB187;  --color-success-bg: #2F3D35;
+  --color-warning:    #DBAE5A;  --color-warning-bg: #453C2C;
+  --color-danger:     #C16E65;  --color-danger-bg:  #3C2623;
+  --color-info:       #0291D5;  --color-info-bg:    #1A3744;
 
-  /* 角色令牌(暗色) */
-  --color-bg-body:        #16181D;
-  --color-bg-container:    #1F2229;
-  --color-bg-elevated:     #262A31;
-  --color-text-primary:    #E8EAED;
-  --color-text-secondary:  #A6ABB5;
-  --color-text-tertiary:   #6E7681;
-  --color-text-disabled:   #4E545E;
-  --color-border:          #363A42;
-  --color-border-strong:   #4A4F58;
-  --color-fill:            #262A31;
-  --color-fill-hover:      #2E333B;
+  /* 角色令牌(暗色:business base-200 画布 / base-100 容器) */
+  --color-bg-body:        #1C1C1C;
+  --color-bg-container:    #202020;
+  --color-bg-elevated:     #292929;
+  --color-text-primary:    #CDCDCD;
+  --color-text-secondary:  #999999;
+  --color-text-tertiary:   #6E6E6E;
+  --color-text-disabled:   #545454;
+  --color-border:          #363636;
+  --color-border-strong:   #4D4D4D;
+  --color-fill:            #2B2B2B;
+  --color-fill-hover:      #343434;
   --color-mask:            rgba(0, 0, 0, 0.65);
-  --color-header-bg:       rgba(31, 34, 41, 0.82);  /* 顶栏底(配 blur) */
+  --color-header-bg:       rgba(32, 32, 32, 0.82);  /* 顶栏底(配 blur) */
 
   /* 阴影(暗底需更重) */
   --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.30), 0 2px 8px rgba(0, 0, 0, 0.35);

--- a/web/src/theme/accents.ts
+++ b/web/src/theme/accents.ts
@@ -1,4 +1,4 @@
-// 6 主色候选(design_handoff §可配置项)。默认 = 第一个靛蓝 #646CFF。
-export const ACCENTS = ['#646CFF', '#7C5CFF', '#0EA5E9', '#EC4899', '#F97316', '#10B981'] as const
+// 6 主色候选(design_handoff §可配置项)。默认 = 第一个 corporate 蓝 #0082CE(spike/theme-refresh:采 daisyUI corporate 主色)。
+export const ACCENTS = ['#0082CE', '#7C5CFF', '#0EA5E9', '#EC4899', '#F97316', '#10B981'] as const
 
 export type Accent = (typeof ACCENTS)[number]

--- a/web/src/theme/naive-theme.ts
+++ b/web/src/theme/naive-theme.ts
@@ -79,5 +79,10 @@ export function buildThemeOverrides(opts: { dark: boolean; accent: string }): Gl
     },
     // 卡片圆角走 lg(12);常规控件走 common.borderRadius(md=10)。
     Card: { borderRadius: v('--radius-lg') },
+    // 表头质感(corporate 风):次级色 + 半粗字重,与数据行拉开层次。
+    DataTable: {
+      thTextColor: v('--color-text-secondary'),
+      thFontWeight: '600',
+    },
   }
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -38,6 +38,15 @@ export default defineConfig({
       '/hub': { target: apiTarget, changeOrigin: true, ws: true }, // SignalR 实时通知 Hub;ws:true 反代 WebSocket 升级
     },
   },
+  // vite preview(产物预览)不继承 server.proxy,这里配同一套;低内存机上用 build+preview 代替 dev 跑整站。
+  preview: {
+    port: 5173,
+    proxy: {
+      '/api': { target: apiTarget, changeOrigin: true },
+      '/openapi': { target: apiTarget, changeOrigin: true },
+      '/hub': { target: apiTarget, changeOrigin: true, ws: true },
+    },
+  },
   test: {
     environment: 'happy-dom',
     include: ['src/**/*.spec.ts'], // 必须限定 src:web/e2e 的 Playwright 用例也叫 *.spec.ts,默认 glob 会误吞


### PR DESCRIPTION
## Context

Evaluated whether \`web/\` could use or switch to daisyUI (saadeghi/daisyui). Verdict from an A/B comparison demo (same user-management page, Naive UI re-themed vs a real Tailwind 4 + daisyUI rebuild): **keep Naive UI, adopt daisyUI's palettes as design material**. daisyUI is a CSS-only Tailwind plugin — no table/tree/form/confirm behavior — while its themes are MIT and portable into our existing token pipeline.

## Changes

- **Palette swap** (\`tokens.css\`): light = daisyUI *corporate*, dark = *business*, OKLCH converted to sRGB hex with the same interpolation as \`mix.ts\`. Radius/typography/shadows keep the in-house rounder scale (daisyUI corporate is 4px radius / depth 0). Default accent becomes corporate blue \`#0082CE\` with an \`afterHydrate\` migration for stale persisted accents.
- **Texture pass** (from a soybean-admin/XiHan survey): cards get a 1px token border (outlines survive dark mode where shadows die), table headers use secondary color + 600 weight, native scrollbars slim to 6px translucent thumbs.
- **Contrast floor enforced**: daisyUI's raw warning (2.5:1) and tertiary text (2.9:1) deepened to \`#A88400\` / \`#85868E\` (≥3.3:1, AA-large). Full measured figures recorded in DESIGN.md §6.
- **Preview proxy** (\`vite.config.ts\`): mirror the dev proxy for \`vite preview\` so build+preview can serve the full app on memory-constrained machines.
- **DESIGN.md** synced: provenance, new accent, brand-indigo carve-out, measured contrast.

## Deliberately unchanged

- Brand identity stays indigo \`#646CFF\` (logo, manifest/browser theme-color) — brand ≠ UI accent, per the existing \`TenonLogo.vue\` principle.
- No Tailwind / daisyUI dependency enters the repo.
- Multi-theme registry (consumer-registrable \`[data-theme]\` sets + switcher UI) is a follow-up, not this PR.

## Verification

- \`npm run typecheck\` green; no test references the old palette.
- A/B screenshots (light/dark × both stacks) archived locally under \`daisyui-demo/compare/\` (throwaway demo project, outside the repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)