### PR TITLE
fix(sqlserver): CodeFirst_BigString for long text (nightly #25)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -128,12 +128,14 @@ jobs:
           # SqlServer full suite builds ~200 isolated databases, each replaying 23 CREATE TABLE whose per-statement
           # log flush dominates — 40-60 min on every push/PR (measured 2026-07-20; see CLAUDE.md "CI"). On push/PR the
           # SqlServer leg runs only the dialect-sensitive subset: the SqlServer-SPECIFIC surface (nvarchar Chinese,
+          # CodeFirst_BigString long-text Chinese — bare ColumnDataType=text is non-Unicode on SqlServer and turns
+          # Chinese into ???, caught by JobSchedulerTests orphan-reape ErrorText asserts / nightly #25;
           # boolean-predicate global filters, T-SQL DDL/bootstrap, Storageable seed SQL, and the scheduler's DateTime
           # equality CAS — datetime rounding is exactly where a silently-never-matching claim would hide). DB-agnostic business logic is
           # already covered by the full sqlite/mysql/postgres legs on the same PR; the full SqlServer suite runs nightly
           # (schedule) as the net. Rename a class out of this list and it silently drops to nightly-only — not a coverage
           # hole, just delayed signal. Other legs and the nightly run are unfiltered.
-          TEST_FILTER: ${{ (matrix.db == 'sqlserver' && github.event_name != 'schedule') && 'FullyQualifiedName~DataScopeTests|FullyQualifiedName~SoftDeleteAuditTests|FullyQualifiedName~OrgAuditEntityTests|FullyQualifiedName~SeedUpgradeTests|FullyQualifiedName~RecycleBinTests|FullyQualifiedName~UserCrudTests|FullyQualifiedName~DictCrudTests|FullyQualifiedName~ReplaceabilityTests|FullyQualifiedName~ProductionBootstrapTests|FullyQualifiedName~JobElectionTests|FullyQualifiedName~JobClaimTests' || '' }}
+          TEST_FILTER: ${{ (matrix.db == 'sqlserver' && github.event_name != 'schedule') && 'FullyQualifiedName~DataScopeTests|FullyQualifiedName~SoftDeleteAuditTests|FullyQualifiedName~OrgAuditEntityTests|FullyQualifiedName~SeedUpgradeTests|FullyQualifiedName~RecycleBinTests|FullyQualifiedName~UserCrudTests|FullyQualifiedName~DictCrudTests|FullyQualifiedName~ReplaceabilityTests|FullyQualifiedName~ProductionBootstrapTests|FullyQualifiedName~JobElectionTests|FullyQualifiedName~JobClaimTests|FullyQualifiedName~JobSchedulerTests' || '' }}
         run: |
           if [ -n "$TEST_FILTER" ]; then
             echo "SqlServer push/PR leg: dialect-sensitive subset only (full SqlServer suite runs nightly)"

--- a/backend/src/TenonAdmin.Services/Entities/SysExceptionLog.cs
+++ b/backend/src/TenonAdmin.Services/Entities/SysExceptionLog.cs
@@ -30,11 +30,12 @@ public class SysExceptionLog : BaseEntity
     public string ExceptionType { get; set; } = "";
 
     /// <summary>异常消息(截断)。只记消息文本,不含请求/响应体。</summary>
-    [SugarColumn(ColumnDataType = "text", IsNullable = true, ColumnDescription = "异常消息")]
+    /// <remarks>SqlServer 禁止裸 text(非 Unicode);见 <c>SysJobLog.ErrorText</c> 同注。</remarks>
+    [SugarColumn(ColumnDataType = StaticConfig.CodeFirst_BigString, IsNullable = true, ColumnDescription = "异常消息")]
     public string? Message { get; set; }
 
     /// <summary>异常堆栈(截断);排障主依据</summary>
-    [SugarColumn(ColumnDataType = "text", IsNullable = true, ColumnDescription = "异常堆栈")]
+    [SugarColumn(ColumnDataType = StaticConfig.CodeFirst_BigString, IsNullable = true, ColumnDescription = "异常堆栈")]
     public string? StackTrace { get; set; }
 
     /// <summary>触发人用户 Id(从当前登录态取,匿名端点为 null;名称按 Id 关联 sys_user,不冗余存)</summary>

--- a/backend/src/TenonAdmin.Services/Entities/SysJob.cs
+++ b/backend/src/TenonAdmin.Services/Entities/SysJob.cs
@@ -31,7 +31,8 @@ public class SysJob : BaseEntity
     public string HandlerName { get; set; } = "";
 
     /// <summary>属性包:Dictionary&lt;string,string?&gt; JSON,处理器参数的唯一入口(键表见台账 §7)</summary>
-    [SugarColumn(ColumnDataType = "text", IsNullable = true, ColumnDescription = "属性包(JSON 字符串字典)")]
+    /// <remarks>SqlServer 禁止裸 text(非 Unicode);见 <c>SysJobLog.ErrorText</c> 同注。</remarks>
+    [SugarColumn(ColumnDataType = StaticConfig.CodeFirst_BigString, IsNullable = true, ColumnDescription = "属性包(JSON 字符串字典)")]
     public string? PropsJson { get; set; }
 
     [SugarColumn(ColumnDescription = "触发类型:1=Cron/2=固定间隔/3=一次性")]

--- a/backend/src/TenonAdmin.Services/Entities/SysJobLog.cs
+++ b/backend/src/TenonAdmin.Services/Entities/SysJobLog.cs
@@ -66,10 +66,15 @@ public class SysJobLog : AuditEntity
     public bool KillRequested { get; set; }
 
     /// <summary>处理器输出(截 8KB;HTTP 响应体截 Http.MaxResponseLogBytes)</summary>
-    [SugarColumn(ColumnDataType = "text", IsNullable = true, ColumnDescription = "输出消息(截断)")]
+    /// <remarks>
+    /// 禁止 <c>ColumnDataType="text"</c>:SqlServer 的 text 是非 Unicode,中文写入后读回成 ???。
+    /// <see cref="StaticConfig.CodeFirst_BigString"/> 在 SqlServer 上解析为 nvarchar(max),其它方言仍是 longtext/text。
+    /// </remarks>
+    [SugarColumn(ColumnDataType = StaticConfig.CodeFirst_BigString, IsNullable = true, ColumnDescription = "输出消息(截断)")]
     public string? MessageText { get; set; }
 
     /// <summary>失败异常信息(截 8KB)</summary>
-    [SugarColumn(ColumnDataType = "text", IsNullable = true, ColumnDescription = "异常信息(截断)")]
+    /// <remarks>同 <see cref="MessageText"/>:须走 CodeFirst_BigString,否则 SqlServer 丢中文(nightly #25)。</remarks>
+    [SugarColumn(ColumnDataType = StaticConfig.CodeFirst_BigString, IsNullable = true, ColumnDescription = "异常信息(截断)")]
     public string? ErrorText { get; set; }
 }

--- a/backend/src/TenonAdmin.Services/Entities/SysNotice.cs
+++ b/backend/src/TenonAdmin.Services/Entities/SysNotice.cs
@@ -43,7 +43,8 @@ public class SysNotice : BaseEntity
     [SugarColumn(Length = 128, ColumnDescription = "标题")]
     public string Title { get; set; } = "";
 
-    // ponytail: 正文限 2000 字符(经全局 string→nvarchar 映射跨方言安全);要富文本/超长正文再改 text 列 + 按方言映射。
+    // ponytail: 正文限 2000 字符(经全局 string→nvarchar 映射跨方言安全)。
+    // 要富文本/超长正文用 StaticConfig.CodeFirst_BigString(SqlServer→nvarchar(max)),禁止裸 ColumnDataType="text"(非 Unicode,中文变 ???)。
     [SugarColumn(Length = 2000, IsNullable = true, ColumnDescription = "正文")]
     public string? Content { get; set; }
 

--- a/backend/src/TenonAdmin.Services/Entities/SysOpLog.cs
+++ b/backend/src/TenonAdmin.Services/Entities/SysOpLog.cs
@@ -26,7 +26,8 @@ public class SysOpLog : BaseEntity
     public string Path { get; set; } = "";
 
     /// <summary>请求入参 JSON(密码等敏感字段已脱敏为 <c>***</c>);超大/不可序列化入参记占位串</summary>
-    [SugarColumn(ColumnDataType = "text", IsNullable = true, ColumnDescription = "入参(脱敏后 JSON)")]
+    /// <remarks>SqlServer 禁止裸 text(非 Unicode);见 <c>SysJobLog.ErrorText</c> 同注。</remarks>
+    [SugarColumn(ColumnDataType = StaticConfig.CodeFirst_BigString, IsNullable = true, ColumnDescription = "入参(脱敏后 JSON)")]
     public string? ParamJson { get; set; }
 
     /// <summary>业务返回码(0 成功,其余见 <c>ErrorCode</c>)</summary>
@@ -41,7 +42,7 @@ public class SysOpLog : BaseEntity
     /// 异常信息:仅动作抛异常时记(异常消息,截断)。业务码已由 ResultCode 表达,此列答"为什么失败";
     /// 成功/纯业务错误(未抛异常)恒 null。<b>只记异常消息不记响应体</b>——响应体可能含明文密码/令牌(设计 §14)。
     /// </summary>
-    [SugarColumn(ColumnDataType = "text", IsNullable = true, ColumnDescription = "异常信息")]
+    [SugarColumn(ColumnDataType = StaticConfig.CodeFirst_BigString, IsNullable = true, ColumnDescription = "异常信息")]
     public string? ExceptionMessage { get; set; }
 
     /// <summary>接口耗时(毫秒)</summary>

--- a/backend/src/TenonAdmin.SqlSugar/SqlSugarSetup.cs
+++ b/backend/src/TenonAdmin.SqlSugar/SqlSugarSetup.cs
@@ -51,6 +51,8 @@ public static class SqlSugarSetup
                 IsAutoCloseConnection = true,
                 // SqlServer CodeFirst 默认把 string 建成 varchar,存中文丢成 "??"(其他方言用 Unicode 类型,无此坑)。
                 // 打开后 string 列建为 nvarchar,跨方言统一走 Unicode。ponytail: SqlSugar 内置开关,一行胜过逐实体标 [SugarColumn]。
+                // 注意:显式 ColumnDataType="text" 仍会建成非 Unicode 的 text,不受本开关影响——超长列须用
+                // StaticConfig.CodeFirst_BigString(SqlServer 上解析为 nvarchar(max);见 SysJobLog.ErrorText)。
                 MoreSettings = new ConnMoreSettings { SqlServerCodeFirstNvarchar = true },
             };
 


### PR DESCRIPTION
## Summary

- Fixes nightly `backend-ci` SqlServer failures from [#25](https://github.com/Tenon-Net/TenonAdmin/issues/25): orphan-reape `ErrorText` Chinese asserts (`失联` / `实例`) failed because bare `ColumnDataType = \"text\"` maps to **non-Unicode** SQL Server `text`.
- Switch long-text columns to `StaticConfig.CodeFirst_BigString` so SqlServer gets `nvarchar(max)` (MySQL `longtext` / others `text`).
- Add `JobSchedulerTests` to the push/PR SqlServer `TEST_FILTER` so this dialect surface is not nightly-only.
- Document the pitfall next to `SqlServerCodeFirstNvarchar` and on the entities.

Touched: `SysJobLog`, `SysExceptionLog`, `SysOpLog`, `SysJob`, comments in `SqlSugarSetup` / `SysNotice`, `backend-ci.yml`.

## Test plan

- [x] `dotnet test backend/TenonAdmin.slnx --filter FullyQualifiedName~JobSchedulerTests` (SQLite) — 11/11
- [x] `dotnet test ... --filter JobExecutorTests|ExceptionLogTests` — 11/11
- [ ] CI `build-test (sqlserver)` push/PR subset (now includes `JobSchedulerTests`)
- [ ] Next nightly full SqlServer suite green → close #25

Closes #25